### PR TITLE
Support correcting Chinese polyphones

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Users in China mainland can refer to https://k2-fsa.org/zh-CN/get-started/k2/.
 To generate speech with our pre-trained ZipVoice or ZipVoice-Distill models, use the following commands (Required models will be downloaded from HuggingFace):
 
 ### 1. Inference of a single sentence:
+
 ```bash
 python3 zipvoice/zipvoice_infer.py \
     --model-name "zipvoice" \
@@ -81,6 +82,7 @@ python3 zipvoice/zipvoice_infer.py \
 - `--model-name` can be `zipvoice` or `zipvoice_distill`, which are models before and after distillation, respectively.
 
 ### 2. Inference of a list of sentences:
+
 ```bash
 python3 zipvoice/zipvoice_infer.py \
     --model-name "zipvoice" \
@@ -90,12 +92,23 @@ python3 zipvoice/zipvoice_infer.py \
 
 - Each line of `test.tsv` is in the format of `{wav_name}\t{prompt_transcription}\t{prompt_wav}\t{text}`.
 
-
 > **Note:** If you have trouble connecting to HuggingFace, try:
 > ```bash
-> export HF_ENDPOINT=https://hf-mirror.co
+> export HF_ENDPOINT=https://hf-mirror.com
 > ```
 
+### 3. Correcting mispronounced chinese polyphone characters
+
+We use [pypinyin](https://github.com/mozillazg/python-pinyin) to convert Chinese characters to pinyin. However, it can occasionally mispronounce **polyphone characters** (多音字).
+
+To manually correct these mispronunciations, enclose the **corrected pinyin** in angle brackets `< >` and include the **tone mark**.
+
+**Example:**
+
+- Original text: `这把剑长三十公分`
+- Correct the pinyin of `长`:  `这把剑<chang2>三十公分`
+
+> **Note:** If you want to manually assign multiple pinyins, enclose each pinyin with `<>`, e.g., `这把<jian4><chang2><san1>十公分`
 
 ## Training Your Own Model
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ python3 zipvoice/zipvoice_infer.py \
 ```
 
 - `--model-name` can be `zipvoice` or `zipvoice_distill`, which are models before and after distillation, respectively.
+- If `<>` or `[]` appear in the text, strings enclosed by them will be treated as special tokens. `<>` denotes Chinese pinyin and `[]` denotes other special tags.
 
 ### 2. Inference of a list of sentences:
 

--- a/zipvoice/generate_averaged_model.py
+++ b/zipvoice/generate_averaged_model.py
@@ -45,10 +45,13 @@ from pathlib import Path
 
 import torch
 from model import get_distill_model, get_model
-from tokenizer import TokenizerEmilia, TokenizerLibriTTS
+from tokenizer import EmiliaTokenizer, LibriTTSTokenizer
 from train_flow import add_model_arguments, get_params
 
-from checkpoint import average_checkpoints_with_averaged_model, find_checkpoints
+from checkpoint import (
+    average_checkpoints_with_averaged_model,
+    find_checkpoints,
+)
 from utils import str2bool
 
 
@@ -122,11 +125,11 @@ def main():
     params.update(vars(args))
 
     if params.dataset == "emilia":
-        tokenizer = TokenizerEmilia(
+        tokenizer = EmiliaTokenizer(
             token_file=params.token_file, token_type=params.token_type
         )
     elif params.dataset == "libritts":
-        tokenizer = TokenizerLibriTTS(
+        tokenizer = LibriTTSTokenizer(
             token_file=params.token_file, token_type=params.token_type
         )
 

--- a/zipvoice/infer.py
+++ b/zipvoice/infer.py
@@ -86,11 +86,14 @@ from checkpoint import load_checkpoint
 from feature import TorchAudioFbank, TorchAudioFbankConfig
 from lhotse.utils import fix_random_seed
 from model import get_distill_model, get_model
-from tokenizer import TokenizerEmilia, TokenizerLibriTTS
+from tokenizer import EmiliaTokenizer, LibriTTSTokenizer
 from train_flow import add_model_arguments, get_params
 from vocos import Vocos
 
-from checkpoint import average_checkpoints_with_averaged_model, find_checkpoints
+from checkpoint import (
+    average_checkpoints_with_averaged_model,
+    find_checkpoints,
+)
 from utils import AttributeDict, setup_logger, str2bool
 
 
@@ -257,7 +260,7 @@ def generate_sentence(
     text: str,
     model: nn.Module,
     vocoder: nn.Module,
-    tokenizer: TokenizerEmilia,
+    tokenizer: EmiliaTokenizer,
     feature_extractor: TorchAudioFbank,
     device: torch.device,
     num_step: int = 16,
@@ -279,7 +282,7 @@ def generate_sentence(
         text (str): Text to be synthesized into a waveform.
         model (nn.Module): The model used for generation.
         vocoder (nn.Module): The vocoder used to convert features to waveforms.
-        tokenizer (TokenizerEmilia): The tokenizer used to convert text to tokens.
+        tokenizer (EmiliaTokenizer): The tokenizer used to convert text to tokens.
         feature_extractor (TorchAudioFbank): The feature extractor used to
             extract acoustic features.
         device (torch.device): The device on which computations are performed.
@@ -381,7 +384,7 @@ def generate(
     params: AttributeDict,
     model: nn.Module,
     vocoder: nn.Module,
-    tokenizer: TokenizerEmilia,
+    tokenizer: EmiliaTokenizer,
 ):
     total_t = []
     total_t_no_vocoder = []
@@ -470,11 +473,11 @@ def main():
     logging.info(f"Device: {params.device}")
 
     if params.dataset == "emilia":
-        tokenizer = TokenizerEmilia(
+        tokenizer = EmiliaTokenizer(
             token_file=params.token_file, token_type=params.token_type
         )
     elif params.dataset == "libritts":
-        tokenizer = TokenizerLibriTTS(
+        tokenizer = LibriTTSTokenizer(
             token_file=params.token_file, token_type=params.token_type
         )
 

--- a/zipvoice/train_distill.py
+++ b/zipvoice/train_distill.py
@@ -82,7 +82,7 @@ from lhotse.cut import Cut, CutSet
 from lhotse.utils import fix_random_seed
 from model import get_distill_model, get_model
 from optim import FixedLRScheduler, ScaledAdam
-from tokenizer import TokenizerEmilia, TokenizerLibriTTS
+from tokenizer import EmiliaTokenizer, LibriTTSTokenizer
 from torch import Tensor
 from torch.amp import GradScaler, autocast
 from torch.nn.parallel import DistributedDataParallel as DDP
@@ -795,11 +795,11 @@ def run(rank, world_size, args):
     logging.info(f"Device: {device}")
 
     if params.dataset == "emilia":
-        tokenizer = TokenizerEmilia(
+        tokenizer = EmiliaTokenizer(
             token_file=params.token_file, token_type=params.token_type
         )
     elif params.dataset == "libritts":
-        tokenizer = TokenizerLibriTTS(
+        tokenizer = LibriTTSTokenizer(
             token_file=params.token_file, token_type=params.token_type
         )
 

--- a/zipvoice/train_flow.py
+++ b/zipvoice/train_flow.py
@@ -61,7 +61,7 @@ from lhotse.cut import Cut, CutSet
 from lhotse.utils import fix_random_seed
 from model import get_model
 from optim import Eden, ScaledAdam
-from tokenizer import TokenizerEmilia, TokenizerLibriTTS
+from tokenizer import EmiliaTokenizer, LibriTTSTokenizer
 from torch import Tensor
 from torch.amp import GradScaler, autocast
 from torch.nn.parallel import DistributedDataParallel as DDP
@@ -906,11 +906,11 @@ def run(rank, world_size, args):
     logging.info(f"Device: {device}")
 
     if params.dataset == "emilia":
-        tokenizer = TokenizerEmilia(
+        tokenizer = EmiliaTokenizer(
             token_file=params.token_file, token_type=params.token_type
         )
     elif params.dataset == "libritts":
-        tokenizer = TokenizerLibriTTS(
+        tokenizer = LibriTTSTokenizer(
             token_file=params.token_file, token_type=params.token_type
         )
     params.vocab_size = tokenizer.vocab_size

--- a/zipvoice/zipvoice_infer.py
+++ b/zipvoice/zipvoice_infer.py
@@ -63,7 +63,7 @@ from feature import TorchAudioFbank, TorchAudioFbankConfig
 from huggingface_hub import hf_hub_download
 from lhotse.utils import fix_random_seed
 from model import get_distill_model, get_model
-from tokenizer import TokenizerEmilia
+from tokenizer import EmiliaTokenizer
 from utils import AttributeDict
 from vocos import Vocos
 
@@ -221,7 +221,7 @@ def generate_sentence(
     text: str,
     model: torch.nn.Module,
     vocoder: torch.nn.Module,
-    tokenizer: TokenizerEmilia,
+    tokenizer: EmiliaTokenizer,
     feature_extractor: TorchAudioFbank,
     device: torch.device,
     num_step: int = 16,
@@ -243,7 +243,7 @@ def generate_sentence(
         text (str): Text to be synthesized into a waveform.
         model (torch.nn.Module): The model used for generation.
         vocoder (torch.nn.Module): The vocoder used to convert features to waveforms.
-        tokenizer (TokenizerEmilia): The tokenizer used to convert text to tokens.
+        tokenizer (EmiliaTokenizer): The tokenizer used to convert text to tokens.
         feature_extractor (TorchAudioFbank): The feature extractor used to
             extract acoustic features.
         device (torch.device): The device on which computations are performed.
@@ -347,7 +347,7 @@ def generate(
     test_list: str,
     model: torch.nn.Module,
     vocoder: torch.nn.Module,
-    tokenizer: TokenizerEmilia,
+    tokenizer: EmiliaTokenizer,
     feature_extractor: TorchAudioFbank,
     device: torch.device,
     num_step: int = 16,
@@ -455,7 +455,7 @@ def main():
         "zhu-han/ZipVoice", filename="tokens_emilia.txt"
     )
 
-    tokenizer = TokenizerEmilia(token_file)
+    tokenizer = EmiliaTokenizer(token_file)
 
     params.vocab_size = tokenizer.vocab_size
     params.pad_id = tokenizer.pad_id


### PR DESCRIPTION
This PR includes two major changes:

1. Support manually correction of  mispronounced chinese polyphone characters  (#4). For example, if `长` is mispronounced in `这把剑长三十公分`, you can correct it with `这把剑<chang2>三十公分`. 
2. Refactor the code in tokenizer.py into two classes, TextNormalizer and Tokenizer, to facilitate future extensions (#3).