### PR TITLE
Fix feature extraction

### DIFF
--- a/zipvoice/feature.py
+++ b/zipvoice/feature.py
@@ -104,6 +104,11 @@ class TorchAudioFbank(FeatureExtractor):
 
         if len(samples.shape) == 1:
             samples = samples.unsqueeze(0)
+        else:
+            assert samples.ndim == 2, samples.shape
+            if samples.shape[0] == 2:
+                samples = samples.mean(dim=0, keepdim=True)
+
         assert samples.ndim == 2, samples.shape
         assert samples.shape[0] == 1, samples.shape
 

--- a/zipvoice/zipvoice_infer.py
+++ b/zipvoice/zipvoice_infer.py
@@ -182,32 +182,6 @@ def get_parser():
     return parser
 
 
-class MelSpectrogramFeatures(torch.nn.Module):
-    def __init__(
-        self,
-        sampling_rate=24000,
-        n_mels=100,
-        n_fft=1024,
-        hop_length=256,
-    ):
-        super().__init__()
-
-        self.mel_spec = torchaudio.transforms.MelSpectrogram(
-            sample_rate=sampling_rate,
-            n_fft=n_fft,
-            hop_length=hop_length,
-            n_mels=n_mels,
-            center=True,
-            power=1,
-        )
-
-    def forward(self, inp):
-        assert len(inp.shape) == 2
-        mel = self.mel_spec(inp)
-        logmel = mel.clamp(min=1e-7).log()
-        return logmel
-
-
 def get_vocoder():
     vocoder = Vocos.from_pretrained("charactr/vocos-mel-24khz")
     return vocoder


### PR DESCRIPTION
1. Remove unused codes;
2. Squeeze stereo audios to one channel if detected.